### PR TITLE
Fixes #7: Add controlfile (control file) directive to be able to add custom control file in the config.tar.gz section

### DIFF
--- a/DotnetMakeDeb/Deb/DebPackage.cs
+++ b/DotnetMakeDeb/Deb/DebPackage.cs
@@ -280,7 +280,7 @@ namespace DotnetMakeDeb.Deb
 						continue;
 					}
 
-					m = Regex.Match(line, @"^contfile\s*:\s*(\S+)\s+(\S+)(?:\s+(text))?$", RegexOptions.IgnoreCase);
+					m = Regex.Match(line, @"^controlfile\s*:\s*(\S+)\s+(\S+)(?:\s+(text))?$", RegexOptions.IgnoreCase);
 					if (m.Success)
 					{
 						// Add data file as control file


### PR DESCRIPTION
Feature:
- Add `controlfile` (control file) directive to be able to add custom control file in the `config.tar.gz` section.
  - This new directive can have value of `SourcePath`, `IsText`, `Mode`, `UserId`, and `GroupId`.
- Adjust `DebPackage.ResolveFileItems()` to allow processing for `null` in `DestPath`.

Clean up:
- Simplify existing implementation of initializing `DebFileItem` objects.
- Make all properties initialization for `DebFileItem` more explicit (explicitly initialized) to make code easier to understand.
- Convert pubic fields in `DebControlParams` and `DebFileItem` to become property with getter setter ([following OOP principle: encapsulation](https://en.wikipedia.org/wiki/Object-oriented_programming#Encapsulation)).

Fixes #7